### PR TITLE
Add support for promises.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,13 @@ bnr.getRates().then((rates) => {
     //   ...
     //   ZAR: { amount: 0.3065, name: 'ZAR', multiplier: 1 }
     // }
-})
+});
+
+// Convert 100 EUR into USD - using promises
+bnr.convert(100, 'EUR', 'USD').then((amount) => {
+    console.log(`Result: ${amount}`);
+     // Result: 107.72102819395911
+});
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ bnr.convert(100, "EUR", "USD", function (err, amount, output) {
     // 100 EUR is 107.72102819395911 USD
 });
 
+// Using promises
+bnr.getRates().then((rates) => {
+    console.log(rates);
+    // { RON: { multiplier: 1, amount: 1, name: 'RON' },
+    //   AED: { amount: 1.1375, name: 'AED', multiplier: 1 },
+    //   ...
+    //   ZAR: { amount: 0.3065, name: 'ZAR', multiplier: 1 }
+    // }
+})
 ```
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,26 @@ const request = require("tinyreq")
 
 const SOURCE = "http://www.bnro.ro/nbrfxrates.xml";
 
+/**
+ * Wrap a callback for promises support.
+ *
+ * @param {function} callback
+ * @param {function} resolve
+ * @param {function} reject
+ * @returns {function(...[*]=)}
+ */
+function wrapCallback(callback, resolve, reject) {
+    return (error, response) => {
+        if (error) {
+            reject(error);
+            callback(error);
+            return;
+        }
+        callback(null, response);
+        resolve(response);
+    }
+}
+
 module.exports = class BNR {
 
     /**
@@ -17,30 +37,33 @@ module.exports = class BNR {
      * @param {Function} cb The callback function.
      */
     static getRates (cb) {
-        let rates = {
-            RON: { multiplier: 1, amount: 1, name: "RON" }
-        };
-        request({
-            url: SOURCE,
-            rejectUnauthorized: false
-        }, (err, body, res) => {
-            if (err) { return cb(err) }
-            if (res.statusCode !== 200 && !err) {
-                err = new Error("Cannot get the currency rates.");
-            }
-            if (err) { return cb(err); }
+        return new Promise((resolve, reject) => {
+            const callback = wrapCallback(cb, resolve, reject);
+            let rates = {
+                RON: { multiplier: 1, amount: 1, name: "RON" }
+            };
+            request({
+                url: SOURCE,
+                rejectUnauthorized: false
+            }, (err, body, res) => {
+                if (err) { return callback(err) }
+                if (res.statusCode !== 200 && !err) {
+                    err = new Error("Cannot get the currency rates.");
+                }
+                if (err) { return callback(err); }
 
-            xml2json(body, (err, data) => {
-                if (err) { return cb(err); }
-                let rawRates = data.Body.Cube.Rate;
-                rawRates.forEach(c => {
-                    rates[c.$.currency] = {
-                        amount: +c._
-                      , name: c.$.currency
-                      , multiplier: +c.$.multiplier || 1
-                    };
+                xml2json(body, (err, data) => {
+                    if (err) { return callback(err); }
+                    let rawRates = data.Body.Cube.Rate;
+                    rawRates.forEach(c => {
+                        rates[c.$.currency] = {
+                            amount: +c._
+                            , name: c.$.currency
+                            , multiplier: +c.$.multiplier || 1
+                        };
+                    });
+                    callback(null, rates);
                 });
-                cb(null, rates);
             });
         });
     }
@@ -57,31 +80,34 @@ module.exports = class BNR {
      * @param {Function} cb The callback function.
      */
     static convert (amount, inputCurrency, outputCurrency, cb) {
-        this.getRates(function (err, rates) {
-            if (err) { return cb(err); }
+        return new Promise((resolve, reject) => {
+            const callback = wrapCallback(cb, resolve, reject);
+            this.getRates(function (err, rates) {
+                if (err) { return callback(err); }
 
-            let sourceCurrency = rates[inputCurrency];
-            if (!sourceCurrency) {
-                return cb(new Error("Invalid input currency: " + inputCurrency));
-            }
-
-            let targetCurrency = rates[outputCurrency];
-            if (!targetCurrency) {
-                return cb(new Error("Invalid output currency: " + outputCurrency));
-            }
-
-            let result = amount * (sourceCurrency.amount / sourceCurrency.multiplier) / (targetCurrency.amount * targetCurrency.multiplier);
-            cb(null, result, {
-                input: {
-                    currency: inputCurrency,
-                    currency_obj: sourceCurrency,
-                    amount: amount
-                },
-                output: {
-                    currency: outputCurrency,
-                    currency_obj: targetCurrency,
-                    amount: result
+                let sourceCurrency = rates[inputCurrency];
+                if (!sourceCurrency) {
+                    return callback(new Error("Invalid input currency: " + inputCurrency));
                 }
+
+                let targetCurrency = rates[outputCurrency];
+                if (!targetCurrency) {
+                    return callback(new Error("Invalid output currency: " + outputCurrency));
+                }
+
+                let result = amount * (sourceCurrency.amount / sourceCurrency.multiplier) / (targetCurrency.amount * targetCurrency.multiplier);
+                callback(null, result, {
+                    input: {
+                        currency: inputCurrency,
+                        currency_obj: sourceCurrency,
+                        amount: amount
+                    },
+                    output: {
+                        currency: outputCurrency,
+                        currency_obj: targetCurrency,
+                        amount: result
+                    }
+                });
             });
         });
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,14 +15,14 @@ const SOURCE = "http://www.bnro.ro/nbrfxrates.xml";
  * @returns {function(...[*]=)}
  */
 function wrapCallback(callback = () => {}, resolve, reject) {
-    return (error, response) => {
+    return (error, ...response) => {
         if (error) {
             callback(error);
             reject(error);
             return;
         }
-        callback(null, response);
-        resolve(response);
+        callback(null, ...response);
+        resolve(...response);
     }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,8 +17,8 @@ const SOURCE = "http://www.bnro.ro/nbrfxrates.xml";
 function wrapCallback(callback, resolve, reject) {
     return (error, response) => {
         if (error) {
-            reject(error);
             callback(error);
+            reject(error);
             return;
         }
         callback(null, response);

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ const SOURCE = "http://www.bnro.ro/nbrfxrates.xml";
 /**
  * Wrap a callback for promises support.
  *
- * @param {function} callback
+ * @param {function(Error, *?)} callback
  * @param {function} resolve
  * @param {function} reject
  * @returns {function(...[*]=)}

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ const SOURCE = "http://www.bnro.ro/nbrfxrates.xml";
 /**
  * Wrap a callback for promises support.
  *
- * @param {function(Error, *?)} callback
+ * @param {function(Error|null, *?)} callback
  * @param {function} resolve
  * @param {function} reject
  * @returns {function(...[*]=)}

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ const SOURCE = "http://www.bnro.ro/nbrfxrates.xml";
  * @param {function} reject
  * @returns {function(...[*]=)}
  */
-function wrapCallback(callback, resolve, reject) {
+function wrapCallback(callback = () => {}, resolve, reject) {
     return (error, response) => {
         if (error) {
             callback(error);

--- a/types/bnr-tests.ts
+++ b/types/bnr-tests.ts
@@ -17,6 +17,16 @@ BNR.getRates((err, rates) => {
     usd = rates['USD'].name;
 });
 
+BNR.getRates().then((rates) => {
+    number = rates.RON.multiplier;
+    number = rates.RON.amount;
+    string = rates.RON.name;
+
+    usd = rates['USD'].name;
+}).catch((err) => {
+    string = err.message;
+});
+
 BNR.convert(55, 'USD', 'RON', (err, result, summary) => {
     usd = summary.input.currency;
     usd = summary.input.currency_obj.name;
@@ -25,4 +35,10 @@ BNR.convert(55, 'USD', 'RON', (err, result, summary) => {
     ron = summary.output.currency;
     ron = summary.output.currency_obj.name;
     number = summary.output.amount;
+});
+
+BNR.convert(55, 'USD', 'RON').then((convertedAmount) => {
+    number = convertedAmount;
+}).catch((error) => {
+    string = error.message;
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -54,7 +54,7 @@ declare class BNR {
     /**
      * Fetch currency exchange rates.
      */
-    static getRates(callback: (err: BNR.CallbackError, rates: BNR.Rates) => any): void;
+    static getRates(callback?: (err: BNR.CallbackError, rates: BNR.Rates) => any): Promise<BNR.Rates>;
 
     /**
      * Convert currencies.
@@ -63,8 +63,8 @@ declare class BNR {
         amount: number,
         inputCurrency: Input,
         outputCurrency: Output,
-        callback: (err: BNR.CallbackError, result: number, summary: { input: ConvertedOutput<Input>, output: ConvertedOutput<Output> }) => any
-    ): void;
+        callback?: (err: BNR.CallbackError, result: number, summary: { input: ConvertedOutput<Input>, output: ConvertedOutput<Output> }) => any
+    ): Promise<number>;
 }
 
 /**


### PR DESCRIPTION
This pull request adds support for Promises to both the `getRates()` and `convert()` methods. Keeping support for the old Node-style callback approach.

This allows for use of the all-so-wonderful [async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await) syntax.
```ts
const rates = await BNR.getRates();
```

But keeps the callback functionality for those who prefer to use that.
```ts
BNR.getRates((rates) => {
    console.log(rates);
});
```